### PR TITLE
Allow transient compilation, without touching the file system

### DIFF
--- a/src/compiler/Compiler.js
+++ b/src/compiler/Compiler.js
@@ -69,7 +69,12 @@ module.exports = class Compiler {
         return this.compile(fs.readFileSync(filename, 'utf-8'), name || filename);
     }
 
-    compile(source, name) {
+    /**
+     * Compiles the given HTL source code into JavaScript, which is returned as a string
+     * @param {String} source the HTL source code
+     * @returns {String} the resulting Javascript
+     */
+    compileTransient(source) {
         // todo: async support
         const commands = new TemplateParser()
             .withErrorListener(ThrowingErrorListener.INSTANCE)
@@ -93,6 +98,19 @@ module.exports = class Compiler {
         let template = fs.readFileSync(path.join(__dirname, codeTemplate), 'utf-8');
         template = template.replace(/^\s*\/\/\s*RUNTIME_GLOBALS\s*$/m, global.join(''));
         template = template.replace(/^\s*\/\/\s*CODE\s*$/m, code);
+
+        return template;
+    }
+
+    /**
+     * Compiles the given source string and saves the result, overwriting the
+     * file name.
+     * @param {String} source HTL template code
+     * @param {String} name file name to save results
+     * @returns {String} the full name of the resulting file
+     */
+    compile(source, name) {
+        const template = this.compileTransient(source);
 
         const filename = this._outfile || path.resolve(this._dir, name);
         fs.writeFileSync(filename, template);

--- a/src/compiler/Compiler.js
+++ b/src/compiler/Compiler.js
@@ -66,7 +66,7 @@ module.exports = class Compiler {
 
     compileFile(filename, name) {
         // todo: async support
-        return this.compile(fs.readFileSync(filename, 'utf-8'), name || filename);
+        return this.compileToFile(fs.readFileSync(filename, 'utf-8'), name || filename);
     }
 
     /**
@@ -74,7 +74,7 @@ module.exports = class Compiler {
      * @param {String} source the HTL source code
      * @returns {String} the resulting Javascript
      */
-    compileTransient(source) {
+    compileToString(source) {
         // todo: async support
         const commands = new TemplateParser()
             .withErrorListener(ThrowingErrorListener.INSTANCE)
@@ -109,12 +109,23 @@ module.exports = class Compiler {
      * @param {String} name file name to save results
      * @returns {String} the full name of the resulting file
      */
-    compile(source, name) {
-        const template = this.compileTransient(source);
+    compileToFile(source, name) {
+        const template = this.compileToString(source);
 
         const filename = this._outfile || path.resolve(this._dir, name);
         fs.writeFileSync(filename, template);
 
         return filename;
+    }
+
+    /**
+     * Compiles the given source string and saves the result, overwriting the
+     * file name.
+     * @param {String} source HTL template code
+     * @param {String} name file name to save results
+     * @returns {String} the full name of the resulting file
+     */
+    compile(source, name) {
+        return this.compileToFile(source, name);
     }
 };


### PR DESCRIPTION
- instead of forcing to write a file, introduces a new compileTransient method, which returns a string