### PR TITLE
#6 Extend .gitignore to exclude generated tests and NPM node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+node_modules/
+test/generated/
 out.js


### PR DESCRIPTION
Updated `.gitignore` to exclude:

```
node_modules/
test/generated/
```

For safety, this should prevent the accidental check-out of unnecessary files.

Resolves #6.