### PR TITLE
#9 Support for data-sly-resource

### DIFF
--- a/src/compiler/ExpressionFormatter.js
+++ b/src/compiler/ExpressionFormatter.js
@@ -154,6 +154,8 @@ module.exports = class ExpressionFormatter {
         this.result += `${node.functionName}(`;
       } else if (node.functionName === 'use') {
         this.result += 'yield use(';
+      } else if (node.functionName === 'resource') {
+        this.result += 'yield slyResource(';
       } else {
         this.result += `exec("${node.functionName}"`;
         delim = ', ';

--- a/src/compiler/JSCodeTemplate.js
+++ b/src/compiler/JSCodeTemplate.js
@@ -26,6 +26,7 @@ module.exports = function main(runtime) {
   const xss = runtime.xss.bind(runtime);
   const listInfo = runtime.listInfo.bind(runtime);
   const use = runtime.use.bind(runtime);
+  const slyResource = runtime.resource.bind(runtime);
 
   return runtime.run(function* () {
 

--- a/src/parser/html/MarkupHandler.js
+++ b/src/parser/html/MarkupHandler.js
@@ -45,6 +45,7 @@ const PLUGINS = {
   test: require('../plugins/TestPlugin'),
   attribute: require('../plugins/AttributePlugin'),
   use: require('../plugins/UsePlugin'),
+  resource: require('../plugins/ResourcePlugin'),
   element: require('../plugins/ElementPlugin'),
 };
 /* eslint-enable global-require */

--- a/src/parser/plugins/ResourcePlugin.js
+++ b/src/parser/plugins/ResourcePlugin.js
@@ -15,32 +15,23 @@
  * limitations under the License.
  *
  */
-/* eslint-disable */
+const Plugin = require('../html/Plugin');
+const OutputVariable = require('../commands/OutputVariable');
+const RuntimeCall = require('../htl/nodes/RuntimeCall');
+const VariableBinding = require('../commands/VariableBinding');
 
-const Runtime = require('@adobe/htlengine/src/runtime/Runtime');
+module.exports = class ResourcePlugin extends Plugin {
+  beforeChildren(stream) {
+    const variableName = this.pluginContext.generateVariable('resourceContent');
+    const runtimeCall = new RuntimeCall('resource', this._expression.root);
+    stream.write(new VariableBinding.Global(variableName, runtimeCall));
+    stream.write(new OutputVariable(variableName));
+    stream.write(VariableBinding.END);
+    stream.beginIgnore();
+  }
 
-function run(runtime) {
-  const lengthOf = function (c) {
-    return Array.isArray(c) ? c.length : Object.keys(c).length;
-  };
-
-  const out = runtime.out.bind(runtime);
-  const exec = runtime.exec.bind(runtime);
-  const xss = runtime.xss.bind(runtime);
-  const listInfo = runtime.listInfo.bind(runtime);
-  const use = runtime.use.bind(runtime);
-  const slyResource = runtime.resource.bind(runtime);
-
-  return runtime.run(function* () {
-
-    // RUNTIME_GLOBALS
-
-    // CODE
-  });
-}
-
-module.exports.main = function main(resource) {
-  const runtime = new Runtime();
-  runtime.setGlobal(resource);
-  return run(runtime).then(() => ({ body: runtime.stream }));
+  // eslint-disable-next-line class-methods-use-this
+  afterChildren(stream) {
+    stream.endIgnore();
+  }
 };

--- a/test/compiler_test.js
+++ b/test/compiler_test.js
@@ -88,6 +88,7 @@ describe('Compiler Tests', () => {
             it(`${idx}. Generates output for '${test.name}' correctly.`, (done) => {
               const runtime = new Runtime()
                 .withUseDirectory(path.join(__dirname, 'specs'))
+                .withResourceDirectory(path.join(__dirname, 'specs'))
                 .setGlobal(payload);
 
               // eslint-disable-next-line import/no-dynamic-require,global-require

--- a/test/interpreter_test.js
+++ b/test/interpreter_test.js
@@ -94,6 +94,10 @@ describe('Interpreter Tests', () => {
         // todo: interpreter support for use classes
         return;
       }
+      if (name === 'resource') {
+        // todo: interpreter support for resource classes
+        return;
+      }
       // eslint-disable-next-line import/no-dynamic-require,global-require
       const payload = require(`./specs/${name}_spec.js`);
 

--- a/test/specs/resource_spec.js
+++ b/test/specs/resource_spec.js
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+module.exports = {};

--- a/test/specs/resource_spec.txt
+++ b/test/specs/resource_spec.txt
@@ -1,8 +1,68 @@
 #
 ### sightly resource function
 #
-<div data-sly-resource="resource_spec/test_page.html"></div>
+<section data-sly-resource="resource_spec/test_page.html"></section>
 ===
-<div><span>Resource</span></div>
+<section><span>Resource</span></section>
+#
+### sightly resource function in expression
+#
+<section data-sly-resource="${'resource_spec/test_page.html'}"></section>
+===
+<section><span>Resource</span></section>
+#
+### sightly resource function with prependPath option
+#
+<section data-sly-resource="${'/test_page.html' @ prependPath='resource_spec/'}"></section>
+===
+<section><span>Resource</span></section>
+#
+### sightly resource function with appendPath option
+#
+<section data-sly-resource="${'resource_spec' @ appendPath='test_page.html'}"></section>
+===
+<section><span>Resource</span></section>
+#
+### slightly resource function with single selectors option
+#
+<section data-sly-resource="${'resource_spec/test_page.html' @ selectors='selector'}"></section>
+===
+<section><span>Resource selector</span></section>
+#
+### slightly resource function with selectors array option 
+#
+<section data-sly-resource="${'resource_spec/test_page.html' @ selectors=['selector']}"></section>
+===
+<section><span>Resource selector</span></section>
+#
+### slightly resource function with single addSelectors option
+#
+<section data-sly-resource="${'resource_spec/test_page.html' @ addSelectors='selector'}"></section>
+===
+<section><span>Resource selector</span></section>
+#
+### slightly resource function with addSelectors array option
+#
+<section data-sly-resource="${'resource_spec/test_page.html' @ addSelectors=['selector']}"></section>
+===
+<section><span>Resource selector</span></section>
+#
+### slightly resource function with single removeSelectors option
+#
+<section data-sly-resource="${'resource_spec/test_page.selector.html' @ removeSelectors='selector'}"></section>
+===
+<section><span>Resource</span></section>
+#
+### slightly resource function with removeSelectors array option
+#
+<section data-sly-resource="${'resource_spec/test_page.selector.html' @ removeSelectors=['selector']}"></section>
+===
+<section><span>Resource</span></section>
+#
+### slightly resource function with removeSelectors option
+#
+<section data-sly-resource="${'resource_spec/test_page.html' @ removeSelectors}"></section>
+===
+<section><span>Resource</span></section>
 #
 ###

--- a/test/specs/resource_spec.txt
+++ b/test/specs/resource_spec.txt
@@ -1,0 +1,8 @@
+#
+### sightly resource function
+#
+<div data-sly-resource="resource_spec/test_page.html"></div>
+===
+<div><span>Resource</span></div>
+#
+###

--- a/test/specs/resource_spec/test_page.html
+++ b/test/specs/resource_spec/test_page.html
@@ -1,0 +1,1 @@
+<span>Resource</span>

--- a/test/specs/resource_spec/test_page.selector.html
+++ b/test/specs/resource_spec/test_page.selector.html
@@ -1,0 +1,1 @@
+<span>Resource selector</span>


### PR DESCRIPTION
#### What the changes intend

Resolves #9, adds support for the `data-sly-resource` block.

#### How they change the existing code

New plugin, `ResourcePlugin.js`, for handling `data-sly-resource` blocks. Presently works in a similar way to the `data-sly-use` blocks. Reads a file from the file-system directly.

For future proofing, its been written in a way that a user can extend the `Runtime` class from `runtime/Runtime.js` and override the `resource` method to perhaps make a GET request or some other special considerations.

A thought; I've used `slyResource` instead of `resource` to avoid conflicts with the existing `resource` runtime globals. Perhaps there is a better name for this function, or each of the runtime functions should be namespaced in a different way.