### PR TITLE
fix(compiler): allow to specify require when using compileToFunction()

### DIFF
--- a/examples/jsdom/index.js
+++ b/examples/jsdom/index.js
@@ -15,7 +15,7 @@ const { JSDOM } = require('jsdom');
 const { Compiler, Runtime } = require('@adobe/htlengine');
 
 const code = ''
-  + '<sly data-sly-use.doc="helper.js"/>'
+  + '<sly data-sly-use.doc="./helper.js"/>'
   + '<!DOCTYPE html>'
   + '<html><head><title>${doc.title}</title></head>\n'
   + '<body>\n'
@@ -40,8 +40,7 @@ async function run() {
   // setup the HTL compiler
   const compiler = new Compiler().withRuntimeVar('document');
 
-  // compile the script to a executable template function
-  const template = await compiler.compileToFunction(code);
+  const template = await compiler.compileToFunction(code, __dirname, require);
 
   // generate the input data using JSDOM
   const document = new JSDOM(html).window.document;


### PR DESCRIPTION
fixes #114

first workaround for module loading using `compileToFunction()`.

example usage:

```js
const { createRequireFromPath } = require('module');
const path = require('path');
.
.
.
// compile the script to a executable template function
const mods = path.resolve(__dirname, '../modules/index.js');
const template = await compiler.compileToFunction(code, '.', createRequireFromPath(mods));
```

