### PR TITLE
Attributes without value are treated as attributes with value = 'true'

### DIFF
--- a/src/runtime/HtmlDOMFactory.js
+++ b/src/runtime/HtmlDOMFactory.js
@@ -54,7 +54,7 @@ module.exports = class HtmlDOMFactory extends DOMFactory {
   }
 
   attr(node, name, value, context) {
-    if (value === true) {
+		if (value === true || value === null) {
       this._out(` ${name}`);
       return;
     }

--- a/src/runtime/HtmlDOMFactory.js
+++ b/src/runtime/HtmlDOMFactory.js
@@ -54,7 +54,7 @@ module.exports = class HtmlDOMFactory extends DOMFactory {
   }
 
   attr(node, name, value, context) {
-		if (value === true || value === null) {
+    if (value === true || value === null) {
       this._out(` ${name}`);
       return;
     }

--- a/src/runtime/VDOMFactory.js
+++ b/src/runtime/VDOMFactory.js
@@ -141,7 +141,7 @@ module.exports = class VDOMFactory extends DOMFactory {
   }
 
   attr(node, name, value) {
-    node.setAttribute(name, value);
+    node.setAttribute(name, value != null ? value : '');
   }
 
   push(parent, node) {

--- a/test/specs/attribute_spec.txt
+++ b/test/specs/attribute_spec.txt
@@ -150,11 +150,16 @@
 ===
 <div class="hello again"></div>
 #
-#
 ### can output vars with colon in property
 #
 <div class="${properties.jcr:content}"></div>
 ===
 <div class="the content"></div>
+#
+### allow for attributes without value
+#
+<input type="checkbox" checked disabled>
+===
+<input type="checkbox" checked disabled>
 #
 ###

--- a/test/specs/attribute_spec_hast.txt
+++ b/test/specs/attribute_spec_hast.txt
@@ -134,4 +134,10 @@
 ===
 <div class="the content"></div>
 #
+### allow for attributes without value
+#
+<input type="checkbox" checked disabled>
+===
+<input type="checkbox" checked disabled>
+#
 ###

--- a/test/specs/attribute_spec_jsd.txt
+++ b/test/specs/attribute_spec_jsd.txt
@@ -140,4 +140,11 @@
 ===
 <div class="the content"></div>
 #
+### allow for attributes without value
+### TODO: Update after JSDOM bug will be fixed https://github.com/jsdom/jsdom/issues/2977
+#
+<input type="checkbox" checked disabled>
+===
+<input type="checkbox" checked="" disabled="">
+#
 ###


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated logic of the attribute filter in HTMLDOMFactory to allow HTML attributes to be passed without any value, and treat them as if it is `true`.

<!--- Describe your changes in detail -->

## Related Issue
#177 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Compiled HTL template with HTML DOM node with attribute but without value.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
