### PR TITLE
Pass expression options to ResourceLoader

### DIFF
--- a/src/parser/plugins/ResourcePlugin.js
+++ b/src/parser/plugins/ResourcePlugin.js
@@ -13,12 +13,13 @@
 const Plugin = require('../html/Plugin');
 const OutputVariable = require('../commands/OutputVariable');
 const RuntimeCall = require('../htl/nodes/RuntimeCall');
+const MapLiteral = require('../htl/nodes/MapLiteral');
 const VariableBinding = require('../commands/VariableBinding');
 
 module.exports = class ResourcePlugin extends Plugin {
   beforeChildren(stream) {
     const variableName = this.pluginContext.generateVariable('resourceContent');
-    const runtimeCall = new RuntimeCall('resource', this._expression.root);
+    const runtimeCall = new RuntimeCall('resource', this._expression.root, [new MapLiteral(this._expression.options)]);
     stream.write(new VariableBinding.Global(variableName, runtimeCall));
     stream.write(new OutputVariable(variableName));
     stream.write(VariableBinding.END);

--- a/src/runtime/Runtime.js
+++ b/src/runtime/Runtime.js
@@ -167,11 +167,11 @@ module.exports = class Runtime {
     });
   }
 
-  resource(uri) {
+  resource(uri, options) {
     if (!this._resourceLoader) {
       return '';
     }
-    return this._resourceLoader(this, uri);
+    return this._resourceLoader(this, uri, options);
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
## Description

Updated logic to allow passing expression options to custom Resource Loader 

## Related Issue

#186 

## Motivation and Context

Allow custom implementation to handle options passed to loader.

## How Has This Been Tested?

I run all the existing test and all are green. This functionality does not change any of the compiled HTML. 
I do not know if there are any test for that logic. If there is please point me to it so I can add the test.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
