### PR TITLE
fix: allow to join strings (#196)

### DIFF
--- a/src/runtime/Runtime.js
+++ b/src/runtime/Runtime.js
@@ -208,7 +208,7 @@ module.exports = class Runtime {
 
   exec(name, value, arg0, arg1) {
     if (name === 'join') {
-      return value.join(arg0 || ', ');
+      return Array.isArray(value) ? value.join(arg0 || ', ') : value;
     }
 
     if (name === 'format') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The join function is meant to join arrays.
For example:

```
${someValue @ join = '-'}
```

However there is one inconsistency with java htl engine.

In java someValue can be a string or undefined.
In javascript only arrays are allowed.

Can you please align both engines?

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#196

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
