### PR TITLE
Refactor template handling

### DIFF
--- a/src/compiler/JSCodeGenVisitor.js
+++ b/src/compiler/JSCodeGenVisitor.js
@@ -12,6 +12,7 @@
 
 const OutText = require('../parser/commands/OutText');
 const VariableBinding = require('../parser/commands/VariableBinding');
+const FileReference = require('../parser/commands/FileReference');
 const FunctionBlock = require('../parser/commands/FunctionBlock');
 const FunctionCall = require('../parser/commands/FunctionCall');
 const Conditional = require('../parser/commands/Conditional');
@@ -127,7 +128,7 @@ module.exports = class JSCodeGenVisitor {
 
     // then process the templates
     this._sourceOffset = 0;
-    templates.forEach((t) => {
+    Object.values(templates).forEach((t) => {
       this._sourceFile = t.file;
       t.commands.forEach((c) => {
         c.accept(this);
@@ -157,6 +158,8 @@ module.exports = class JSCodeGenVisitor {
       mappings: this._main.map,
       templateCode,
       templateMappings,
+      // eslint-disable-next-line no-underscore-dangle
+      globalTemplateNames: Object.keys(this._dom._globalTemplates),
     };
   }
 
@@ -212,6 +215,8 @@ module.exports = class JSCodeGenVisitor {
       this.out(`const ${ExpressionFormatter.escapeVariable(cmd.variableName)} = ${exp};`);
     } else if (cmd instanceof VariableBinding.End) {
       // nop
+    } else if (cmd instanceof FileReference) {
+      this._dom.bindFunction(cmd);
     } else if (cmd instanceof FunctionBlock.Start) {
       this.pushBlock(cmd.expression);
       this._dom.functionStart(cmd);

--- a/src/compiler/ScriptResolver.js
+++ b/src/compiler/ScriptResolver.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const path = require('path');
+const fse = require('fs-extra');
+
+/**
+ * Creates a script resolver.
+ * @param {string[]} roots Root directories for resolution.
+ */
+module.exports = function createResolver(roots) {
+  if (!Array.isArray(roots)) {
+    // eslint-disable-next-line no-param-reassign
+    roots = [roots];
+  }
+
+  /**
+   * Resolves the script against the given roots.
+   * @param {string} baseDir additional root
+   * @param {string} uri script uri
+   * @returns {Promise<string>}
+   */
+  async function resolve(baseDir, uri) {
+    let bases = [baseDir, ...roots];
+
+    // if uri starts with '.' or '..', only consider specified bases.
+    // otherwise also consider apps and libs.
+    if (!uri.startsWith('./') && !uri.startsWith('../')) {
+      bases = bases.reduce((prev, root) => {
+        prev.push(root);
+        prev.push(path.resolve(root, 'apps'));
+        prev.push(path.resolve(root, 'libs'));
+        return prev;
+      }, []);
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const base of bases) {
+      const scriptPath = path.resolve(base, uri);
+      // eslint-disable-next-line no-await-in-loop
+      if (await fse.pathExists(scriptPath)) {
+        return scriptPath;
+      }
+    }
+    throw Error(`Unable to resolve script: ${uri}. Search Path: ${bases}`);
+  }
+
+  return resolve;
+};

--- a/src/compiler/TemplateLoader.js
+++ b/src/compiler/TemplateLoader.js
@@ -9,61 +9,20 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-const path = require('path');
 const fse = require('fs-extra');
 
 /**
  * Creates an template loader.
- * @param {string[]} roots Root directories for resolution.
  */
-module.exports = function createLoader(roots) {
-  if (!Array.isArray(roots)) {
-    // eslint-disable-next-line no-param-reassign
-    roots = [roots];
-  }
-
+module.exports = function createLoader() {
   /**
-   * Resolves the template against the given roots.
-   * @param {string} baseDir additional root
-   * @param {string} uri template uri
-   * @returns {Promise<string>}
+   * @param {string} filePath Template path
+   * @returns {Promise<>} the template source and  path
    */
-  async function resolve(baseDir, uri) {
-    let bases = [baseDir, ...roots];
-
-    // if uri starts with '.' or '..', only consider specified bases.
-    // otherwise also consider apps and libs.
-    if (!uri.startsWith('./') && !uri.startsWith('../')) {
-      bases = bases.reduce((prev, root) => {
-        prev.push(root);
-        prev.push(path.resolve(root, 'apps'));
-        prev.push(path.resolve(root, 'libs'));
-        return prev;
-      }, []);
-    }
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const base of bases) {
-      const templatePath = path.resolve(base, uri);
-      // eslint-disable-next-line no-await-in-loop
-      if (await fse.pathExists(templatePath)) {
-        return templatePath;
-      }
-    }
-    throw Error(`Unable to resolve template: ${uri}. Search Path: ${bases}`);
-  }
-
-  /**
-   * Load the template.
-   * @param {string} baseDir additional root
-   * @param {string} uri template uri
-   * @returns {Promise<>} the template source and resolved path
-   */
-  async function load(baseDir, uri) {
-    const templatePath = await resolve(baseDir, uri);
+  async function load(filePath) {
     return {
-      data: await fse.readFile(templatePath, 'utf-8'),
-      path: templatePath,
+      data: await fse.readFile(filePath, 'utf-8'),
+      path: filePath,
     };
   }
 

--- a/src/parser/commands/CommandStream.js
+++ b/src/parser/commands/CommandStream.js
@@ -21,8 +21,8 @@ module.exports = class CommandStream {
     this._ignore = 0;
   }
 
-  write(command) {
-    if (this._ignore) {
+  write(command, force) {
+    if (this._ignore && !force) {
       return;
     }
     const isText = command instanceof OutText;

--- a/src/parser/commands/FileReference.js
+++ b/src/parser/commands/FileReference.js
@@ -12,12 +12,13 @@
 
 const Command = require('./Command');
 
-module.exports = class TemplateReference extends Command {
+module.exports = class FileReference extends Command {
   constructor(name, filename, args) {
     super();
     this._name = name;
     this._filename = filename;
     this._args = args || [];
+    this._id = null;
   }
 
   get name() {
@@ -26,6 +27,14 @@ module.exports = class TemplateReference extends Command {
 
   get filename() {
     return this._filename;
+  }
+
+  set id(value) {
+    this._id = value;
+  }
+
+  get id() {
+    return this._id;
   }
 
   get args() {

--- a/src/parser/commands/FunctionBlock.js
+++ b/src/parser/commands/FunctionBlock.js
@@ -18,6 +18,15 @@ class Start extends Command {
     super();
     this._expression = expression;
     this._options = options;
+    this._id = null;
+  }
+
+  set id(value) {
+    this._id = value;
+  }
+
+  get id() {
+    return this._id;
   }
 
   get expression() {

--- a/src/parser/plugins/TemplatePlugin.js
+++ b/src/parser/plugins/TemplatePlugin.js
@@ -12,20 +12,18 @@
 const Plugin = require('../html/Plugin');
 
 module.exports = class TemplatePlugin extends Plugin {
-  // eslint-disable-next-line class-methods-use-this
   beforeElement(stream) {
-    stream.beginIgnore();
-  }
-
-  beforeChildren(stream) {
     const variableName = this._signature.getVariableName(null);
-
     if (variableName === null) {
       throw new Error('data-sly-template must be called with an identifier');
     }
-
-    stream.endIgnore();
     stream.beginFunction(variableName, this._expression.options);
+    stream.beginIgnore();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  beforeChildren(stream) {
+    stream.endIgnore();
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/parser/plugins/UsePlugin.js
+++ b/src/parser/plugins/UsePlugin.js
@@ -11,7 +11,7 @@
  */
 
 const Plugin = require('../html/Plugin');
-const TemplateReference = require('../commands/TemplateReference');
+const FileReference = require('../commands/FileReference');
 const MapLiteral = require('../htl/nodes/MapLiteral');
 const StringConstant = require('../htl/nodes/StringConstant');
 
@@ -22,9 +22,9 @@ module.exports = class UsePlugin extends Plugin {
     const variableName = this._signature.getVariableName(DEFAULT_VARIABLE_NAME);
     if (this._expression.root instanceof StringConstant) {
       const lib = this._expression.root.text;
-      stream.write(new TemplateReference(
+      stream.write(new FileReference(
         variableName, lib, [new MapLiteral(this._expression.options)],
-      ));
+      ), true);
       return;
     }
     throw new Error('data-sly-use only supports static references.');

--- a/src/runtime/Runtime.js
+++ b/src/runtime/Runtime.js
@@ -206,23 +206,23 @@ module.exports = class Runtime {
     return this.run(callable);
   }
 
-  template(name, callback) {
-    if (!name) {
-      // this is called to retrieve the template map, so that it looks like the template is
-      // like a function reference
-      return this._templates;
+  /**
+   * Registers a template.
+   * @param {string} id The id of the use group
+   * @param {string} name The name of the template function
+   * @param {Function} fn Template function
+   * @returns {object} the use group.
+   */
+  template(id, name, fn) {
+    let group = this._templates[id];
+    if (!group) {
+      group = {};
+      this._templates[id] = group;
     }
-
-    return name.split('.').reduce((prev, seg, idx, arr) => {
-      if (idx === arr.length - 1) {
-        // eslint-disable-next-line no-param-reassign
-        prev[seg] = callback;
-      } else {
-        // eslint-disable-next-line no-param-reassign
-        prev[seg] = prev[seg] || {};
-      }
-      return prev[seg];
-    }, this._templates);
+    if (name) {
+      group[name] = fn;
+    }
+    return group;
   }
 
   exec(name, value, arg0, arg1) {

--- a/test/compiler_test.js
+++ b/test/compiler_test.js
@@ -22,7 +22,7 @@ const { JSDOM } = require('jsdom');
 const Runtime = require('../src/runtime/Runtime');
 const fsResourceLoader = require('../src/runtime/fsResourceLoader');
 const Compiler = require('../src/compiler/Compiler');
-const TemplateLoader = require('../src/compiler/TemplateLoader.js');
+const ScriptResolver = require('../src/compiler/ScriptResolver.js');
 
 function serializeDom(node) {
   if (node.doctype) {
@@ -89,7 +89,7 @@ function runTests(specs, typ = '', runtimeFn = () => {}, resultFn = (ret) => ret
     }
     const compiler = new Compiler()
       .withDirectory(outputDir)
-      .withTemplateLoader(TemplateLoader([outputDir, rootProject1]))
+      .withScriptResolver(ScriptResolver([outputDir, rootProject1]))
       .withRuntimeVar(Object.keys(payload))
       .withSourceFile(sourceFile)
       .withSourceMap(true);

--- a/test/specs/call_spec.txt
+++ b/test/specs/call_spec.txt
@@ -24,7 +24,7 @@
 <div><section>Template</section></div>
 ^^^
 37:     $.dom.append($n, var_0);
-46:     yield $.call($.template().foo, [$n, {"param": "Template", }]);
+47:     yield $.call(foo, [$n, {"param": "Template", }]);
 #
 ### sightly call function with colon in name
 #
@@ -51,7 +51,7 @@
 <div><section></section></div>
 ^^^
 37:     $.dom.append($n, var_0);
-46:     yield $.call($.template().foo, [$n, {}]);
+47:     yield $.call(foo, [$n, {}]);
 #
 ### sightly call function can be redeclared
 #
@@ -82,7 +82,7 @@
 
 ^^^
 37:     $.dom.append($n, var_0);
-49:     yield $.call($.template().foo, [$n, {}]);
+50:     yield $.call(foo, [$n, {}]);
 #
 ### sightly call function can call other templates
 #
@@ -106,9 +106,9 @@
 </div>
 </div>
 ^^^
-39:     yield $.call($.template().bar, [$n, {"a": a, }]);
+39:     yield $.call(bar, [$n, {"a": a, }]);
 52:     $.dom.append($n, var_0);
-63:     yield $.call($.template().foo, [$n, {"a": 123, }]);
+65:     yield $.call(foo, [$n, {"a": 123, }]);
 #
 ### sightly call function can call itself recursively
 #
@@ -174,7 +174,7 @@
 ^^^
 37:     if (var_size1) {
 49:         $.dom.append($n, var_3);
-51:         yield $.call($.template().foo, [$n, {"pages": item["pages"], }]);
-66:     yield $.call($.template().foo, [$n, {"pages": bar["pages"], }]);
+51:         yield $.call(foo, [$n, {"pages": item["pages"], }]);
+67:     yield $.call(foo, [$n, {"pages": bar["pages"], }]);
 #
 ###

--- a/test/specs/template_spec.js
+++ b/test/specs/template_spec.js
@@ -20,5 +20,22 @@ module.exports = {
   },
   page: {
     title: 'This is the title',
+    list: [
+      { title: 'item 1', children: [] },
+      {
+        title: 'item 2',
+        children: [
+          { title: 'item 2.1', children: [] },
+          {
+            title: 'item 2.2',
+            children: [
+              { title: ' item 2.2.1', children: [] },
+            ],
+          },
+          { title: 'item 2.3', children: [] },
+        ],
+      },
+      { title: 'item 2', children: [] },
+    ],
   },
 };

--- a/test/specs/template_spec.txt
+++ b/test/specs/template_spec.txt
@@ -9,8 +9,8 @@ blah 1
 #
 ### use external template lib and invoke template 2
 #
-<div data-sly-call="${lib.two}"></div>
 <sly data-sly-use.lib="template_spec/templateLib.html"></sly>
+<div data-sly-call="${lib.two}"></div>
 ===
 <div>blah 2</div>
 
@@ -58,13 +58,13 @@ blah Hello, world.
 
 </div>
 ^^^
-40:     $.dom.append($n, var_0);
-51:     $.dom.append($n, var_0);
-62:       yield $.call($.template().comps["button"], [$n, {"data": data, }]);
-67:       yield $.call($.template().comps["heading"], [$n, {"data": data, }]);
-78:     $.dom.append($n, var_0);
-85:     yield $.call($.template().lib["lib"], [$n, {"name": "heading", "data": component["data"], }]);
-92:     yield $.call($.template().lib["lib"], [$n, {"name": component["name"], "data": component["data"], }]);
+42:       yield $.call(comps1["button"], [$n, {"data": data, }]);
+47:       yield $.call(comps2["heading"], [$n, {"data": data, }]);
+58:     $.dom.append($n, var_0);
+69:     $.dom.append($n, var_0);
+81:     $.dom.append($n, var_0);
+88:     yield $.call(lib["lib"], [$n, {"name": "heading", "data": component["data"], }]);
+95:     yield $.call(lib["lib"], [$n, {"name": component["name"], "data": component["data"], }]);
 #
 ### template defining and calling another template
 #
@@ -76,10 +76,10 @@ blah Hello, world.
 </div>
 </div>
 ^^^
-40:     $.dom.append($n, var_0);
-57:     $.dom.append($n, var_0);
-65:     yield $.call($.template().lib["bar"], [$n, {"a": a, }]);
-74:     yield $.call($.template().lib["foo"], [$n, {"a": 123, }]);
+46:     $.dom.append($n, var_0);
+55:     yield $.call(lib["bar"], [$n, {"a": a, }]);
+66:     $.dom.append($n, var_0);
+76:     yield $.call(lib["foo"], [$n, {"a": 123, }]);
 #
 ### template can use global var
 #
@@ -97,4 +97,21 @@ blah Hello, world.
     <h1>Project This is the title</h1>
 </div>
 #
+### recursive template calls
+#
+<div data-sly-use.lib="template_spec/group.htl" data-sly-call="${lib.group @ items=page.list}"></div>
+===
+<div><ul><li>item 1</li>
+<li>item 2<ul><li>item 2.1</li>
+<li>item 2.2<ul><li> item 2.2.1</li>
+</ul>
+</li>
+<li>item 2.3</li>
+</ul>
+</li>
+<li>item 2</li>
+</ul>
+</div>
+#
 ###
+#

--- a/test/specs/template_spec/group.htl
+++ b/test/specs/template_spec/group.htl
@@ -1,0 +1,3 @@
+<template data-sly-template.group="${@ items='The navigation items for the current level'}" data-sly-use.itemTemplate="item.htl"><!--/*
+    */--><ul data-sly-list="${items}"><sly data-sly-call="${itemTemplate.item @ item=item}"></sly></ul>
+</template>

--- a/test/specs/template_spec/item.htl
+++ b/test/specs/template_spec/item.htl
@@ -1,0 +1,3 @@
+<template data-sly-template.item="${@ item='The navigation item'}" data-sly-use.groupTemplate="group.htl"><!--/*
+    */--><li>${item.title}<sly data-sly-test="${item.children.length > 0}" data-sly-call="${groupTemplate.group @ items = item.children}"></sly></li>
+</template>

--- a/test/specs/template_spec/library.htl
+++ b/test/specs/template_spec/library.htl
@@ -1,6 +1,7 @@
-<sly data-sly-use.comps="./button.htl"/>
-<sly data-sly-use.comps="./heading.htl"/>
-<template data-sly-template.lib="${@ name, data}">
-<sly data-sly-test="${name == 'button'}" data-sly-call="${comps.button @ data=data}" />
-<sly data-sly-test="${name == 'heading'}" data-sly-call="${comps.heading @ data=data}" />
+<template
+        data-sly-template.lib="${@ name, data}"
+        data-sly-use.comps1="./button.htl"
+        data-sly-use.comps2="./heading.htl">
+<sly data-sly-test="${name == 'button'}" data-sly-call="${comps1.button @ data=data}" />
+<sly data-sly-test="${name == 'heading'}" data-sly-call="${comps2.heading @ data=data}" />
 </template>

--- a/test/specs/template_spec_hast.txt
+++ b/test/specs/template_spec_hast.txt
@@ -9,8 +9,8 @@ blah 1
 #
 ### use external template lib and invoke template 2
 #
-<div data-sly-call="${lib.two}"></div>
 <sly data-sly-use.lib="template_spec/templateLib.html"></sly>
+<div data-sly-call="${lib.two}"></div>
 ===
 <div>blah 2</div>
 
@@ -33,7 +33,7 @@ blah Hello, world.
     <button>This is a button</button>
 </div>
 #
-###
+### components
 #
 <sly data-sly-use.lib="template_spec/library.htl"/>
 <h1>${page.title}</h1>


### PR DESCRIPTION
### BREAKING CHANGE:

- The `templateLoader` and `scriptResolver` are now 2  separate functions that can be set on the compiler
- The `Runtime.template()` has an extra argument 'id'  that specifies the group (script) the template is defined.

fixes #216 #208 