### PR TITLE
fix(dep): tmp fix for antlr4 issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,9 +1022,9 @@
       "dev": true
     },
     "antlr4": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.7.2.tgz",
-      "integrity": "sha512-vZA1xYufXLe3LX+ja9rIVxjRmILb1x3k7KYZHltRbfJtXjJ1DlFIqt+CbPYmghx0EuzY9DajiDw+MdyEt1qAsQ=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
     },
     "anymatch": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "./node_modules/.bin/eslint ."
   },
   "dependencies": {
-    "antlr4": "^4.7.2",
+    "antlr4": "4.8.0",
     "fs-extra": "^9.0.0",
     "he": "^1.2.0",
     "moment": "^2.24.0",


### PR DESCRIPTION
Fix #264 
Fixing antlr4 dependency to version 4.8.0 should fix the issue (until they solve their backward compatibility issue). This assumes this project does not need the latest version.