### PR TITLE
fix(compiler): escape all dashes in SymbolGenerator

### DIFF
--- a/src/parser/html/SymbolGenerator.js
+++ b/src/parser/html/SymbolGenerator.js
@@ -19,7 +19,7 @@ module.exports = class SymbolGenerator {
   }
 
   next(hint) {
-    const middle = hint ? hint.replace('-', '_') : '';
+    const middle = hint ? hint.replace(/-/g, '_') : '';
     this._counter += 1;
     return this._prefix + middle + this._counter;
   }

--- a/test/specs/attribute_spec.txt
+++ b/test/specs/attribute_spec.txt
@@ -168,4 +168,10 @@
 ===
 <a>test</a>
 #
+### add attribute with many dashes
+#
+<div data-sly-attribute.data-cmp-contentfragment-path="${properties.myValues}"></div>
+===
+<div data-cmp-contentfragment-path="some data value"></div>
+#
 ###


### PR DESCRIPTION
fixes #284
